### PR TITLE
Fix to: Media player prepare() Blocks UI thread.

### DIFF
--- a/app/src/main/java/com/minafkamel/musically/ui/streaming/StreamingFragment.kt
+++ b/app/src/main/java/com/minafkamel/musically/ui/streaming/StreamingFragment.kt
@@ -34,9 +34,13 @@ class StreamingFragment : BaseFragment<StreamingViewModel>(R.layout.f_streaming)
         }
         mediaPlayer = MediaPlayer()
             .apply {
+                setOnPreparedListener {
+                    // Starting the media player when it is prepared.
+                    it.start()
+                }
                 setDataSource(streamUrl)
-                prepare()
-                start()
+                // When the media player is prepared as Async, it will not block the UI thread.
+                prepareAsync()
             }
     }
 


### PR DESCRIPTION
The fix concentrates on moving the media-player prepare from Main thread to background thread.

** in you current setup, you can see that the GIF/ UI tends to freeze at the time of preparation. you can avoid this by just shifting the MediaPlayer.prepare() to prepareAsync() and starting the player when the media content is prepared.